### PR TITLE
Sanitize brand aria-label in header

### DIFF
--- a/header.php
+++ b/header.php
@@ -17,7 +17,7 @@
       <div class="site-header__bar">
         <div class="container">
           <div class="brand-wrap">
-            <a class="brand" href="<?php echo esc_url(home_url('/')); ?>" aria-label="<?php bloginfo('name'); ?>">
+            <a class="brand" href="<?php echo esc_url(home_url('/')); ?>" aria-label="<?php echo esc_attr( get_bloginfo('name') ); ?>">
               <?php if (has_custom_logo()) : ?>
                 <span class="brand__logo">
                   <?php the_custom_logo(); ?>


### PR DESCRIPTION
## Summary
- Escape the site name in the header brand link using `esc_attr( get_bloginfo('name') )`

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4b6bfdb08326a000a5c450828bb3