### PR TITLE
Add helper for resolving 'sobre' page links

### DIFF
--- a/404.php
+++ b/404.php
@@ -57,7 +57,7 @@ get_header(); ?>
                         </div>
                         
                         <div class="col-md-6 col-lg-3">
-                            <a href="<?php echo esc_url(get_permalink(get_page_by_path('sobre'))); ?>" class="btn btn-outline-primary w-100 h-100 d-flex flex-column align-items-center justify-content-center p-3">
+                            <a href="<?php echo esc_url(agert_get_page_link('sobre')); ?>" class="btn btn-outline-primary w-100 h-100 d-flex flex-column align-items-center justify-content-center p-3">
                                 <i class="bi bi-info-circle fs-2 mb-2"></i>
                                 <span><?php _e('Sobre a AGERT', 'agert'); ?></span>
                             </a>

--- a/footer.php
+++ b/footer.php
@@ -37,7 +37,7 @@
                     <h6 class="mb-3">Links Úteis</h6>
                     <ul class="list-unstyled">
                         <li class="mb-2">
-                            <a href="<?php echo esc_url(get_permalink(get_page_by_path('sobre'))); ?>" class="text-white-50 text-decoration-none">
+                            <a href="<?php echo esc_url(agert_get_page_link('sobre')); ?>" class="text-white-50 text-decoration-none">
                                 <i class="bi bi-arrow-right me-2"></i>Sobre a AGERT
                             </a>
                         </li>

--- a/front-page.php
+++ b/front-page.php
@@ -20,7 +20,7 @@ get_header(); ?>
                     <?php _e('Garantindo a qualidade e eficiência dos serviços públicos delegados, com transparência e compromisso com o cidadão timonense.', 'agert'); ?>
                 </p>
                 <div class="d-flex flex-wrap gap-3">
-                    <a href="<?php echo esc_url(get_permalink(get_page_by_path('sobre'))); ?>" class="btn btn-light btn-lg">
+                    <a href="<?php echo esc_url(agert_get_page_link('sobre')); ?>" class="btn btn-light btn-lg">
                         <i class="bi bi-info-circle me-2"></i>
                         <?php _e('Conheça a AGERT', 'agert'); ?>
                     </a>
@@ -52,7 +52,7 @@ get_header(); ?>
                     'icon' => 'bi-info-circle',
                     'title' => __('Sobre a AGERT', 'agert'),
                     'description' => __('Conheça nossa missão, visão e estrutura organizacional', 'agert'),
-                    'link' => get_permalink(get_page_by_path('sobre'))
+                    'link' => agert_get_page_link('sobre')
                 ),
                 array(
                     'icon' => 'bi-calendar-event',

--- a/functions.php
+++ b/functions.php
@@ -281,3 +281,19 @@ function agert_upload_mimes($mimes) {
     return $mimes;
 }
 add_filter('upload_mimes', 'agert_upload_mimes');
+
+/**
+ * Retorna o link de uma página pelo slug ou a URL inicial como fallback.
+ *
+ * @param string $slug Slug da página desejada.
+ * @return string URL da página ou da home.
+ */
+function agert_get_page_link($slug) {
+    $page = get_page_by_path($slug);
+
+    if ($page instanceof WP_Post) {
+        return get_permalink($page->ID);
+    }
+
+    return home_url('/');
+}

--- a/index.php
+++ b/index.php
@@ -155,7 +155,7 @@ get_header(); ?>
                         </div>
                         <div class="card-body">
                             <div class="d-grid gap-2">
-                                <a href="<?php echo esc_url(get_permalink(get_page_by_path('sobre'))); ?>" class="btn btn-outline-primary btn-sm">
+                                <a href="<?php echo esc_url(agert_get_page_link('sobre')); ?>" class="btn btn-outline-primary btn-sm">
                                     <i class="bi bi-info-circle me-2"></i>
                                     <?php _e('Sobre a AGERT', 'agert'); ?>
                                 </a>

--- a/search.php
+++ b/search.php
@@ -306,7 +306,7 @@ get_header(); ?>
                                 <i class="bi bi-calendar-event me-2"></i>
                                 <?php _e('Todas as Reuniões', 'agert'); ?>
                             </a>
-                            <a href="<?php echo esc_url(get_permalink(get_page_by_path('sobre'))); ?>" class="btn btn-outline-primary btn-sm">
+                            <a href="<?php echo esc_url(agert_get_page_link('sobre')); ?>" class="btn btn-outline-primary btn-sm">
                                 <i class="bi bi-info-circle me-2"></i>
                                 <?php _e('Sobre a AGERT', 'agert'); ?>
                             </a>


### PR DESCRIPTION
## Summary
- add `agert_get_page_link` helper with home fallback
- use helper for 'sobre' links in front-page, footer, search, 404 and index templates

## Testing
- `php -l functions.php front-page.php footer.php search.php 404.php index.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4b705de88326b09698a2f7db3105