### PR TITLE
Add fallback for main navigation menu

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -243,6 +243,19 @@ add_filter('nav_menu_css_class', function($classes, $item) {
     return $classes;
 }, 10, 2);
 
+if (!function_exists('agert_menu_fallback')) {
+    /**
+     * Fallback para o menu principal exibindo páginas básicas.
+     */
+    function agert_menu_fallback() {
+        echo '<ul class="menu">';
+        wp_list_pages([
+            'title_li' => '',
+        ]);
+        echo '</ul>';
+    }
+}
+
 /**
  * Permite preenchimento de exemplo via querystring (?seed_sobre=1).
  */

--- a/header.php
+++ b/header.php
@@ -40,7 +40,7 @@
                 'menu_class'     => 'menu',
                 'link_before'    => '<span>',
                 'link_after'     => '</span>',
-                'fallback_cb'    => false,
+                'fallback_cb'    => 'agert_menu_fallback',
               ]);
             ?>
           </nav>


### PR DESCRIPTION
## Summary
- provide a custom fallback callback for the main navigation
- ensure basic pages are listed when no menu is assigned

## Testing
- `php -l header.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4b7aef8c83268a70400de1e2ac87