### PR TITLE
Optimize meeting option loading with AJAX

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -16,6 +16,7 @@
         initFormValidation();
         initTooltips();
         initScrollToTop();
+        initMeetingSelect();
         
         // Debug mode
         if (window.location.search.includes('debug=1')) {
@@ -137,6 +138,45 @@
             window.scrollTo({
                 top: 0,
                 behavior: 'smooth'
+            });
+        });
+    }
+
+    /**
+     * Carregar reuniões via AJAX em selects
+     */
+    function initMeetingSelect() {
+        const selects = document.querySelectorAll('select[data-load-meetings]');
+
+        selects.forEach(function(select) {
+            let loaded = false;
+            const placeholder = select.querySelector('option[value=""]')?.textContent || '';
+
+            select.addEventListener('focus', function() {
+                if (loaded) return;
+                loaded = true;
+
+                const params = new URLSearchParams();
+                params.append('action', 'agert_get_meetings');
+                params.append('nonce', agert_ajax.nonce);
+
+                ajaxRequest(agert_ajax.ajax_url, { body: params.toString() })
+                    .then(function(response) {
+                        if (response.success && Array.isArray(response.data)) {
+                            select.innerHTML = '';
+                            const option = document.createElement('option');
+                            option.value = '';
+                            option.textContent = placeholder;
+                            select.appendChild(option);
+
+                            response.data.forEach(function(item) {
+                                const opt = document.createElement('option');
+                                opt.value = item.id;
+                                opt.textContent = item.title;
+                                select.appendChild(opt);
+                            });
+                        }
+                    });
             });
         });
     }

--- a/page-anexos.php
+++ b/page-anexos.php
@@ -125,8 +125,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_attachment_non
                     </div>
                     <div class="mb-3">
                         <label for="reuniao_id" class="form-label"><?php _e('Reunião', 'agert'); ?></label>
-                        <select id="reuniao_id" name="reuniao_id" class="form-select" required>
-                            <?php echo agert_get_meetings_options(); ?>
+                        <select id="reuniao_id" name="reuniao_id" class="form-select" required data-load-meetings>
+                            <option value=""><?php _e('Selecione uma reunião', 'agert'); ?></option>
                         </select>
                     </div>
                 </div>

--- a/page-participantes.php
+++ b/page-participantes.php
@@ -125,8 +125,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_participant_no
                     </div>
                     <div class="mb-3">
                         <label for="reuniao_id" class="form-label"><?php _e('Reunião', 'agert'); ?></label>
-                        <select id="reuniao_id" name="reuniao_id" class="form-select" required>
-                            <?php echo agert_get_meetings_options(); ?>
+                        <select id="reuniao_id" name="reuniao_id" class="form-select" required data-load-meetings>
+                            <option value=""><?php _e('Selecione uma reunião', 'agert'); ?></option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Optimize meeting option retrieval using `WP_Query` with ID-only fields and a post limit
- Add AJAX endpoint and frontend script to load meeting options asynchronously
- Update attachment and participant pages to use dynamic meeting lists

## Testing
- `php -l inc/template-functions.php`
- `php -l page-anexos.php`
- `php -l page-participantes.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4b7febc08326bf7fc56eab29f416