### PR TITLE
Add script to fetch vendor assets with CDN fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+assets/vendor/

--- a/ASSETS.md
+++ b/ASSETS.md
@@ -1,0 +1,9 @@
+# Gerenciamento de Assets
+
+Este projeto não inclui arquivos binários de terceiros no repositório. Para baixar o Bootstrap, Bootstrap Icons e as fontes Poppins para uso local, execute o script:
+
+```bash
+./scripts/fetch-assets.sh
+```
+
+Os arquivos serão salvos em `assets/vendor/`, que é ignorado pelo Git. Caso o script não seja executado, o tema carregará essas dependências diretamente das CDNs oficiais.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Para instruções detalhadas de instalação e requisitos, consulte o [INSTALL.m
 ## Desenvolvimento
 O tema utiliza apenas PHP, HTML, CSS e JavaScript simples. Nenhum build step adicional é necessário.
 
+## Assets
+Os arquivos do Bootstrap, Bootstrap Icons e das fontes Poppins não são versionados. Antes de desenvolver ou implantar, execute:
+
+```bash
+./scripts/fetch-assets.sh
+```
+
+Isso criará `assets/vendor/` com as dependências. Caso não execute o script, o tema fará uso das CDNs oficiais como fallback.
+

--- a/functions.php
+++ b/functions.php
@@ -67,29 +67,35 @@ add_action('widgets_init', 'agert_widgets_init');
  * Enqueue scripts and styles
  */
 function agert_scripts() {
-    // Bootstrap CSS
-    wp_enqueue_style(
-        'bootstrap',
-        'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css',
-        array(),
-        '5.3.0'
-    );
-    
-    // Bootstrap Icons
-    wp_enqueue_style(
-        'bootstrap-icons',
-        'https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css',
-        array(),
-        '1.11.0'
-    );
+    $vendor_dir = get_template_directory() . '/assets/vendor';
+    $vendor_uri = get_template_directory_uri() . '/assets/vendor';
 
-    // Google Fonts
-    wp_enqueue_style(
-        'agert-fonts',
-        'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap',
-        array(),
-        null
-    );
+    $bootstrap_version = '5.3.0';
+    $icons_version     = '1.11.0';
+
+    // Bootstrap CSS
+    $bootstrap_css = $vendor_dir . '/bootstrap/bootstrap.min.css';
+    if (file_exists($bootstrap_css)) {
+        wp_enqueue_style('bootstrap', $vendor_uri . '/bootstrap/bootstrap.min.css', array(), $bootstrap_version);
+    } else {
+        wp_enqueue_style('bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@' . $bootstrap_version . '/dist/css/bootstrap.min.css', array(), $bootstrap_version);
+    }
+
+    // Bootstrap Icons
+    $icons_css = $vendor_dir . '/bootstrap-icons/bootstrap-icons.css';
+    if (file_exists($icons_css)) {
+        wp_enqueue_style('bootstrap-icons', $vendor_uri . '/bootstrap-icons/bootstrap-icons.css', array(), $icons_version);
+    } else {
+        wp_enqueue_style('bootstrap-icons', 'https://cdn.jsdelivr.net/npm/bootstrap-icons@' . $icons_version . '/font/bootstrap-icons.css', array(), $icons_version);
+    }
+
+    // Poppins fonts
+    $poppins_css = $vendor_dir . '/poppins/poppins.css';
+    if (file_exists($poppins_css)) {
+        wp_enqueue_style('agert-fonts', $vendor_uri . '/poppins/poppins.css', array(), null);
+    } else {
+        wp_enqueue_style('agert-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap', array(), null);
+    }
 
     // Design tokens
     wp_enqueue_style(
@@ -147,13 +153,12 @@ function agert_scripts() {
     }
     
     // Bootstrap JS (sem jQuery)
-    wp_enqueue_script(
-        'bootstrap',
-        'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js',
-        array(),
-        '5.3.0',
-        true
-    );
+    $bootstrap_js = $vendor_dir . '/bootstrap/bootstrap.bundle.min.js';
+    if (file_exists($bootstrap_js)) {
+        wp_enqueue_script('bootstrap', $vendor_uri . '/bootstrap/bootstrap.bundle.min.js', array(), $bootstrap_version, true);
+    } else {
+        wp_enqueue_script('bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@' . $bootstrap_version . '/dist/js/bootstrap.bundle.min.js', array(), $bootstrap_version, true);
+    }
     
     // Theme JS (apenas se necessário)
     $theme_js_path = get_template_directory() . '/assets/js/theme.js';

--- a/scripts/fetch-assets.sh
+++ b/scripts/fetch-assets.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENDOR_DIR="$ROOT_DIR/assets/vendor"
+
+BOOTSTRAP_VERSION="5.3.0"
+ICONS_VERSION="1.11.0"
+
+mkdir -p "$VENDOR_DIR/bootstrap" "$VENDOR_DIR/bootstrap-icons/fonts" "$VENDOR_DIR/poppins"
+
+curl -L -o "$VENDOR_DIR/bootstrap/bootstrap.min.css" "https://cdn.jsdelivr.net/npm/bootstrap@${BOOTSTRAP_VERSION}/dist/css/bootstrap.min.css"
+curl -L -o "$VENDOR_DIR/bootstrap/bootstrap.bundle.min.js" "https://cdn.jsdelivr.net/npm/bootstrap@${BOOTSTRAP_VERSION}/dist/js/bootstrap.bundle.min.js"
+
+curl -L -o "$VENDOR_DIR/bootstrap-icons/bootstrap-icons.css" "https://cdn.jsdelivr.net/npm/bootstrap-icons@${ICONS_VERSION}/font/bootstrap-icons.css"
+curl -L -o "$VENDOR_DIR/bootstrap-icons/fonts/bootstrap-icons.woff" "https://cdn.jsdelivr.net/npm/bootstrap-icons@${ICONS_VERSION}/font/fonts/bootstrap-icons.woff"
+curl -L -o "$VENDOR_DIR/bootstrap-icons/fonts/bootstrap-icons.woff2" "https://cdn.jsdelivr.net/npm/bootstrap-icons@${ICONS_VERSION}/font/fonts/bootstrap-icons.woff2"
+
+curl -L -o "$VENDOR_DIR/poppins/poppins.css" "https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+
+(
+  cd "$VENDOR_DIR/poppins"
+  for url in $(grep -o 'https://fonts.gstatic.com[^)]*' poppins.css); do
+    fname=$(basename "$url")
+    curl -L -o "$fname" "$url"
+    sed -i "s@$url@$fname@g" poppins.css
+  done
+)
+
+echo "Assets fetched in $VENDOR_DIR"


### PR DESCRIPTION
## Summary
- ignore vendor assets and add script to download Bootstrap, Icons and Poppins
- load local vendor files in `functions.php` with CDN fallbacks
- document asset fetching in README and ASSETS.md

## Testing
- `bash -n scripts/fetch-assets.sh`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689f50e08a448326a143b9534ebcbc60