### PR TITLE
Make contact page contact info configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Para instruções detalhadas de instalação e requisitos, consulte o [INSTALL.m
 ## Desenvolvimento
 O tema utiliza apenas PHP, HTML, CSS e JavaScript simples. Nenhum build step adicional é necessário.
 
+## Configuração de Contato
+Os dados exibidos em **Contato** (endereço, telefone, e-mail e mapa) são lidos das opções do WordPress:
+
+- `agert_contact_address`
+- `agert_contact_phone`
+- `agert_contact_email`
+- `agert_contact_map_url`
+
+Edite essas opções em `wp-admin/options.php` ou via um plugin de gerenciamento de opções para atualizar as informações da página.
+
 ## Assets
 Os arquivos do Bootstrap, Bootstrap Icons e das fontes Poppins não são versionados. Antes de desenvolver ou implantar, execute:
 

--- a/page-contato.php
+++ b/page-contato.php
@@ -34,6 +34,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['contact_nonce'])) {
         $error_message = __('Falha na validação do formulário.', 'agert');
     }
 }
+
+$contact_address = get_option('agert_contact_address', 'Rua dos Reguladores, 123 - Centro, Timon/MA');
+$contact_phone   = get_option('agert_contact_phone', '(99) 3212-3456');
+$contact_email   = get_option('agert_contact_email', 'contato@agert.timon.ma.gov.br');
+$contact_map_url = get_option('agert_contact_map_url', 'https://www.google.com/maps?q=Timon+MA&output=embed');
 ?>
 
 <div class="container py-5">
@@ -71,12 +76,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['contact_nonce'])) {
 
         <div class="col-lg-6">
             <h2 class="h5 mb-3"><?php _e('Informações de Contato', 'agert'); ?></h2>
-            <p class="mb-2"><i class="bi bi-geo-alt me-1"></i>Rua dos Reguladores, 123 - Centro, Timon/MA</p>
-            <p class="mb-2"><i class="bi bi-telephone me-1"></i>(99) 3212-3456</p>
-            <p class="mb-4"><i class="bi bi-envelope me-1"></i>contato@agert.timon.ma.gov.br</p>
+            <p class="mb-2"><i class="bi bi-geo-alt me-1"></i><?php echo esc_html($contact_address); ?></p>
+            <p class="mb-2"><i class="bi bi-telephone me-1"></i><?php echo esc_html($contact_phone); ?></p>
+            <p class="mb-4"><i class="bi bi-envelope me-1"></i><?php echo esc_html($contact_email); ?></p>
 
             <div class="ratio ratio-16x9">
-                <iframe src="https://www.google.com/maps?q=Timon+MA&output=embed" allowfullscreen loading="lazy"></iframe>
+                <iframe src="<?php echo esc_url($contact_map_url); ?>" allowfullscreen loading="lazy"></iframe>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Load contact information and map URL from WordPress options instead of hard-coded values
- Document how to update contact page details in the README

## Testing
- `php -l page-contato.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5e3e5e2c8326930d8755ee4e91a5