### PR TITLE
Implement static fallback menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Tema WordPress responsivo para a Agência Reguladora de Serviços Públicos Dele
 2. No painel do WordPress, ative **AGERT - Tema Oficial**.
 3. Ao ativar, o tema cria automaticamente as páginas **Reuniões**, **Anexos** e **Participantes**, além do menu "Menu Principal".
 
+Após a ativação você pode personalizar os links do menu em **Aparência > Menus**.
+Caso nenhum menu seja configurado, o tema exibirá um menu inicial com links para Home, Sobre a AGERT, Presidente, Reuniões e Contato.
+
 Para instruções detalhadas de instalação e requisitos, consulte o [INSTALL.md](INSTALL.md).
 
 ## Recursos

--- a/functions.php
+++ b/functions.php
@@ -250,13 +250,58 @@ add_filter('nav_menu_css_class', function($classes, $item) {
 
 if (!function_exists('agert_menu_fallback')) {
     /**
-     * Fallback para o menu principal exibindo páginas básicas.
+     * Fallback para o menu principal com links fixos.
      */
     function agert_menu_fallback() {
-        echo '<ul class="menu">';
-        wp_list_pages([
-            'title_li' => '',
-        ]);
+        $items = [
+            [
+                'url'        => home_url('/'),
+                'label'      => __('Início', 'agert'),
+                'is_current' => is_front_page(),
+            ],
+            [
+                'url'        => agert_get_page_link('sobre-a-agert'),
+                'label'      => __('Sobre a AGERT', 'agert'),
+                'is_current' => is_page(['sobre-a-agert', 'sobre']),
+            ],
+            [
+                'url'        => agert_get_page_link('presidente'),
+                'label'      => __('Presidente', 'agert'),
+                'is_current' => is_page('presidente'),
+            ],
+            [
+                'url'        => get_post_type_archive_link('reuniao'),
+                'label'      => __('Reuniões', 'agert'),
+                'is_current' => is_post_type_archive('reuniao') || is_singular('reuniao'),
+            ],
+            [
+                'url'        => agert_get_page_link('contato'),
+                'label'      => __('Contato', 'agert'),
+                'is_current' => is_page('contato'),
+            ],
+        ];
+
+        echo '<ul class="menu" role="menubar">';
+        foreach ($items as $item) {
+            if (empty($item['url'])) {
+                continue;
+            }
+
+            $classes = ['menu-item'];
+            $aria_current = '';
+            if ($item['is_current']) {
+                $classes[]   = 'current-menu-item';
+                $aria_current = ' aria-current="page"';
+            }
+
+            printf(
+                '<li class="%1$s" role="none"><a href="%2$s"%3$s role="menuitem"><span>%4$s</span></a></li>',
+                esc_attr(implode(' ', $classes)),
+                esc_url($item['url']),
+                $aria_current,
+                esc_html($item['label'])
+            );
+        }
         echo '</ul>';
     }
 }

--- a/header.php
+++ b/header.php
@@ -42,6 +42,7 @@
                 'theme_location' => 'primary',
                 'container'      => false,
                 'menu_class'     => 'menu',
+                'items_wrap'     => '<ul class="%2$s" role="menubar">%3$s</ul>',
                 'link_before'    => '<span>',
                 'link_after'     => '</span>',
                 'fallback_cb'    => 'agert_menu_fallback',


### PR DESCRIPTION
## Summary
- replace dynamic page listing with explicit fallback menu items
- expose menu items with ARIA roles
- document how to customize the default menu via WordPress

## Testing
- `php -l functions.php`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5e4278a88326bc54cdab286b969b