### PR TITLE
Exibe indicadores de anexos e vídeos nas reuniões

### DIFF
--- a/page-reunioes.php
+++ b/page-reunioes.php
@@ -17,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_meeting_nonce'
         $local = sanitize_text_field($_POST['local']);
         $pauta = sanitize_textarea_field($_POST['pauta']);
         $tipo_reuniao = sanitize_text_field($_POST['tipo_reuniao']);
+        $video_url = isset($_POST['video_url']) ? esc_url_raw($_POST['video_url']) : '';
         
         if (!empty($title) && !empty($data_hora)) {
             $meeting_id = wp_insert_post(array(
@@ -32,6 +33,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_meeting_nonce'
                 update_post_meta($meeting_id, '_data_hora', $data_hora);
                 update_post_meta($meeting_id, '_local', $local);
                 update_post_meta($meeting_id, '_pauta', $pauta);
+                if ($video_url) {
+                    update_post_meta($meeting_id, '_video_url', $video_url);
+                }
                 
                 // Definir taxonomia se selecionada
                 if (!empty($tipo_reuniao)) {
@@ -101,13 +105,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_meeting_nonce'
                         $status_class = agert_get_meeting_status_class(get_the_ID());
                         $status_text = agert_get_meeting_status_text(get_the_ID());
                         $tipos = get_the_terms(get_the_ID(), 'tipo_reuniao');
+                        $attachments = agert_get_meeting_attachments(get_the_ID());
+                        $video_url = get_post_meta(get_the_ID(), '_video_url', true);
 
                         get_template_part('template-parts/reunioes/meeting-card', null, array(
-                            'status_class' => $status_class,
-                            'status_text'  => $status_text,
-                            'tipos'        => $tipos,
-                            'data_hora'    => $data_hora,
-                            'local'        => $local,
+                            'status_class'    => $status_class,
+                            'status_text'     => $status_text,
+                            'tipos'           => $tipos,
+                            'data_hora'       => $data_hora,
+                            'local'           => $local,
+                            'has_attachments' => !empty($attachments),
+                            'has_video'       => !empty($video_url),
                         ));
                     endwhile; ?>
                 </div>
@@ -269,7 +277,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_meeting_nonce'
                             <label for="pauta" class="form-label"><?php _e('Pauta', 'agert'); ?></label>
                             <textarea class="form-control" id="pauta" name="pauta" rows="3" placeholder="<?php _e('Descreva os principais pontos da reunião...', 'agert'); ?>"></textarea>
                         </div>
-                        
+
+                        <div class="col-12">
+                            <label for="video_url" class="form-label"><?php _e('URL do Vídeo', 'agert'); ?></label>
+                            <input type="url" class="form-control" id="video_url" name="video_url" placeholder="<?php _e('Link do vídeo da reunião (YouTube, etc.)', 'agert'); ?>">
+                        </div>
+
                         <div class="col-12">
                             <label for="meeting_content" class="form-label"><?php _e('Descrição/Observações', 'agert'); ?></label>
                             <textarea class="form-control" id="meeting_content" name="meeting_content" rows="4" placeholder="<?php _e('Informações adicionais sobre a reunião...', 'agert'); ?>"></textarea>

--- a/single-reuniao.php
+++ b/single-reuniao.php
@@ -80,10 +80,10 @@ if (have_posts()) :
                         </div>
                     <?php endif; ?>
 
-                    <?php if (!empty($videos) && is_array($videos)) : ?>
-                        <div class="card card-soft mb-4" id="transmissao">
-                            <div class="card-body">
-                                <h6 class="fw-semibold mb-3">Transmissão/Vídeos</h6>
+                    <div class="card card-soft mb-4" id="transmissao">
+                        <div class="card-body">
+                            <h6 class="fw-semibold mb-3">Transmissão/Vídeos</h6>
+                            <?php if (!empty($videos) && is_array($videos)) : ?>
                                 <?php foreach ($videos as $vid) :
                                     $url = $vid['video_url'] ?? '';
                                     if (!$url) { continue; }
@@ -96,14 +96,20 @@ if (have_posts()) :
                                     </div>
                                     <?php if (!empty($vid['descricao']) || !empty($vid['duracao_segundos'])) : ?>
                                         <p class="text-muted small mb-3">
-                                            <?php if (!empty($vid['duracao_segundos'])) : ?><?php echo esc_html(agert_seconds_to_mmss((int) $vid['duracao_segundos'])); ?><?php endif; ?>
-                                            <?php if (!empty($vid['descricao'])) : ?><?php echo esc_html($vid['descricao']); ?><?php endif; ?>
+                                            <?php if (!empty($vid['duracao_segundos'])) : ?>
+                                                <?php echo esc_html(agert_seconds_to_mmss((int) $vid['duracao_segundos'])); ?>
+                                            <?php endif; ?>
+                                            <?php if (!empty($vid['descricao'])) : ?>
+                                                <?php echo esc_html($vid['descricao']); ?>
+                                            <?php endif; ?>
                                         </p>
                                     <?php endif; ?>
                                 <?php endforeach; ?>
-                            </div>
+                            <?php else : ?>
+                                <p class="text-muted mb-0">Nenhum vídeo disponível</p>
+                            <?php endif; ?>
                         </div>
-                    <?php endif; ?>
+                    </div>
 
                     <?php if (!empty($pauta) && is_array($pauta)) : ?>
                         <div class="card card-soft mb-4">

--- a/template-parts/reunioes/meeting-card.php
+++ b/template-parts/reunioes/meeting-card.php
@@ -15,6 +15,8 @@ $defaults = array(
     'tipos'        => array(),
     'data_hora'    => '',
     'local'        => '',
+    'has_attachments' => false,
+    'has_video'       => false,
 );
 $args = wp_parse_args($args, $defaults);
 ?>
@@ -51,9 +53,17 @@ $args = wp_parse_args($args, $defaults);
             <?php endif; ?>
 
             <div class="d-flex justify-content-between align-items-center mt-3">
-                <a href="<?php the_permalink(); ?>" class="btn btn-sm btn-outline-primary">
-                    <i class="bi bi-eye me-1"></i><?php _e('Ver Detalhes', 'agert'); ?>
-                </a>
+                <div class="d-flex align-items-center gap-2">
+                    <a href="<?php the_permalink(); ?>" class="btn btn-sm btn-outline-primary">
+                        <i class="bi bi-eye me-1"></i><?php _e('Ver Detalhes', 'agert'); ?>
+                    </a>
+                    <?php if ($args['has_attachments']) : ?>
+                        <i class="bi bi-paperclip text-muted" title="<?php esc_attr_e('Possui anexos', 'agert'); ?>"></i>
+                    <?php endif; ?>
+                    <?php if ($args['has_video']) : ?>
+                        <i class="bi bi-camera-video text-muted" title="<?php esc_attr_e('Possui vídeo', 'agert'); ?>"></i>
+                    <?php endif; ?>
+                </div>
                 <?php if (has_excerpt()) : ?>
                     <small class="text-muted"><?php echo esc_html(get_the_excerpt()); ?></small>
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add retrieval of meeting attachments and optional video indicator to meeting cards
- show default message when no videos are available in meeting detail
- allow specifying a video URL when creating meetings

## Testing
- `php -l page-reunioes.php template-parts/reunioes/meeting-card.php single-reuniao.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5e47e23083268f7a27d26f00b7cb