### PR TITLE
Add informational cards to meetings archive

### DIFF
--- a/archive-reuniao.php
+++ b/archive-reuniao.php
@@ -277,4 +277,14 @@ switch ($tab) {
 }
 ?>
 </div>
+<section class="container py-5 reunioes-info">
+    <div class="card-soft p-4 mb-4">
+        <h2 class="h5 mb-3">Informações Gerais das Reuniões</h2>
+        <p>As reuniões ordinárias do Conselho são realizadas regularmente e seus documentos oficiais são disponibilizados nesta página para consulta pública.</p>
+    </div>
+    <div class="card-soft p-4">
+        <h2 class="h5 mb-3">Participação Pública</h2>
+        <p>O público pode acompanhar as sessões e enviar contribuições por meio dos canais disponibilizados. Incentivamos a participação ativa da sociedade nas discussões.</p>
+    </div>
+</section>
 <?php get_footer(); ?>

--- a/assets/css/reunioes.css
+++ b/assets/css/reunioes.css
@@ -104,3 +104,14 @@ body.post-type-archive-reuniao {
     margin-right: .5rem;
     color: #94a3b8;
 }
+
+.reunioes-info {
+    display: grid;
+    gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+    .reunioes-info {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}


### PR DESCRIPTION
## Summary
- add general information and public participation cards to meetings archive
- implement responsive grid styles for new section

## Testing
- `php -l archive-reuniao.php`


------
https://chatgpt.com/codex/tasks/task_e_689f64a86244832680a81eb48fa77457