### PR TITLE
feat: add empty video state card

### DIFF
--- a/assets/css/reunioes.css
+++ b/assets/css/reunioes.css
@@ -104,3 +104,20 @@ body.post-type-archive-reuniao {
     margin-right: .5rem;
     color: #94a3b8;
 }
+
+.video-empty {
+    padding: 2rem;
+    text-align: center;
+}
+
+.video-empty i {
+    font-size: 2.5rem;
+    color: var(--muted);
+    display: block;
+    margin-bottom: .5rem;
+}
+
+.video-empty p {
+    color: var(--muted);
+    margin: 0;
+}

--- a/single-reuniao.php
+++ b/single-reuniao.php
@@ -106,7 +106,10 @@ if (have_posts()) :
                                     <?php endif; ?>
                                 <?php endforeach; ?>
                             <?php else : ?>
-                                <p class="text-muted mb-0">Nenhum vídeo disponível</p>
+                                <div class="card-soft video-empty">
+                                    <i class="bi bi-camera-video-off" aria-hidden="true"></i>
+                                    <p>Nenhum vídeo disponível</p>
+                                </div>
                             <?php endif; ?>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- show icon card when meeting has no videos
- style empty video card in reunioes.css

## Testing
- `php -l single-reuniao.php`


------
https://chatgpt.com/codex/tasks/task_e_689f64b1eeec8326b1ed0a7f05e9ff36