### PR TITLE
feat: add contact info cards

### DIFF
--- a/page-contato.php
+++ b/page-contato.php
@@ -76,9 +76,23 @@ $contact_map_url = get_option('agert_contact_map_url', 'https://www.google.com/m
 
         <div class="col-lg-6">
             <h2 class="h5 mb-3"><?php _e('Informações de Contato', 'agert'); ?></h2>
-            <p class="mb-2"><i class="bi bi-geo-alt me-1"></i><?php echo esc_html($contact_address); ?></p>
-            <p class="mb-2"><i class="bi bi-telephone me-1"></i><?php echo esc_html($contact_phone); ?></p>
-            <p class="mb-4"><i class="bi bi-envelope me-1"></i><?php echo esc_html($contact_email); ?></p>
+            <div class="row row-cols-1 row-cols-md-3 g-3 mb-4">
+                <?php get_template_part('template-parts/contato/card-info', null, array(
+                    'icon'  => 'bi-geo-alt',
+                    'label' => __('Endereço', 'agert'),
+                    'text'  => $contact_address,
+                )); ?>
+                <?php get_template_part('template-parts/contato/card-info', null, array(
+                    'icon'  => 'bi-telephone',
+                    'label' => __('Telefone', 'agert'),
+                    'text'  => $contact_phone,
+                )); ?>
+                <?php get_template_part('template-parts/contato/card-info', null, array(
+                    'icon'  => 'bi-envelope',
+                    'label' => __('E-mail', 'agert'),
+                    'text'  => $contact_email,
+                )); ?>
+            </div>
 
             <div class="ratio ratio-16x9">
                 <iframe src="<?php echo esc_url($contact_map_url); ?>" allowfullscreen loading="lazy"></iframe>

--- a/template-parts/contato/card-info.php
+++ b/template-parts/contato/card-info.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Card com informação de contato reutilizável.
+ *
+ * @package AGERT
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$defaults = array(
+    'icon'  => '',
+    'label' => '',
+    'text'  => '',
+);
+$args = wp_parse_args($args, $defaults);
+?>
+<div class="col">
+    <div class="card-soft p-4 h-100">
+        <div class="d-flex align-items-start">
+            <?php if ($args['icon']) : ?>
+                <i class="bi <?php echo esc_attr($args['icon']); ?> fs-3 me-3" aria-hidden="true"></i>
+            <?php endif; ?>
+            <div>
+                <?php if ($args['label']) : ?>
+                    <p class="mb-1 fw-semibold"><?php echo esc_html($args['label']); ?></p>
+                <?php endif; ?>
+                <?php if ($args['text']) : ?>
+                    <p class="mb-0"><?php echo esc_html($args['text']); ?></p>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- replace contact page paragraphs with card grid and icons
- add reusable `card-info` partial for contact cards

## Testing
- `php -l page-contato.php`
- `php -l template-parts/contato/card-info.php`


------
https://chatgpt.com/codex/tasks/task_e_689f64ae3f6083269194f77b266c08c5