### PR TITLE
Add Vídeos page template and menu integration

### DIFF
--- a/inc/activation.php
+++ b/inc/activation.php
@@ -26,17 +26,30 @@ function agert_create_pages() {
             'title'   => 'Participantes',
             'content' => '<p>Registre participantes das reuniões.</p>'
         ),
+        'videos' => array(
+            'title'   => 'Vídeos',
+            'content' => '<p>Confira os vídeos das reuniões.</p>',
+            'template' => 'page-videos.php',
+        ),
     );
 
     foreach ($pages as $slug => $page_data) {
-        if (!get_page_by_path($slug)) {
-            wp_insert_post(array(
+        $page = get_page_by_path($slug);
+        if (!$page) {
+            $page_id = wp_insert_post(array(
                 'post_title'   => $page_data['title'],
                 'post_content' => $page_data['content'],
                 'post_status'  => 'publish',
                 'post_type'    => 'page',
                 'post_name'    => $slug,
             ));
+            if (!is_wp_error($page_id) && isset($page_data['template'])) {
+                update_post_meta($page_id, '_wp_page_template', $page_data['template']);
+            }
+        } else {
+            if (isset($page_data['template'])) {
+                update_post_meta($page->ID, '_wp_page_template', $page_data['template']);
+            }
         }
     }
 }
@@ -50,7 +63,7 @@ function agert_create_menu() {
 
     if (!$menu) {
         $menu_id = wp_create_nav_menu($menu_name);
-        $pages = array('reunioes', 'anexos', 'participantes');
+        $pages = array('reunioes', 'anexos', 'participantes', 'videos');
         $order = 1;
         foreach ($pages as $slug) {
             $page = get_page_by_path($slug);

--- a/page-videos.php
+++ b/page-videos.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Template Name: Vídeos
+ * Description: Página que lista os vídeos das reuniões.
+ *
+ * @package AGERT
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+get_header();
+
+$paged = get_query_var('paged') ? (int) get_query_var('paged') : 1;
+$params = array('paged' => $paged);
+$videos_data = agert_coletar_videos($params);
+$per_page = 9;
+$videos_slice = array_slice($videos_data['results'], ($paged - 1) * $per_page, $per_page);
+$total_pages = max(1, (int) ceil($videos_data['total'] / $per_page));
+?>
+
+<div class="container py-5">
+    <h1 class="text-center mb-4"><?php _e('Vídeos', 'agert'); ?></h1>
+    <?php if ($videos_slice) : ?>
+        <div class="row g-4">
+            <?php foreach ($videos_slice as $item) :
+                $video = $item['video'];
+                $meeting = $item['meeting'];
+            ?>
+                <div class="col-sm-6 col-lg-4">
+                    <?php get_template_part('parts/reunioes/card-video', null, array('video' => $video, 'meeting' => $meeting)); ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+        <?php if ($total_pages > 1) : ?>
+            <nav class="mt-4">
+                <?php echo paginate_links(array(
+                    'current' => $paged,
+                    'total'   => $total_pages,
+                )); ?>
+            </nav>
+        <?php endif; ?>
+    <?php else : ?>
+        <p class="text-center text-muted"><?php _e('Nenhum vídeo encontrado.', 'agert'); ?></p>
+    <?php endif; ?>
+</div>
+
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- add `page-videos.php` template that lists videos with pagination
- auto-create and register the "Vídeos" page with its template and add it to the primary menu

## Testing
- `php -l page-videos.php`
- `php -l inc/activation.php`


------
https://chatgpt.com/codex/tasks/task_e_689f682184cc8326a9e0a54daade6ecc